### PR TITLE
Fix CMake linker error with GTest.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ include_directories(${GTEST_INCLUDE_DIRS})
 
 # add test executable and link to gtest libs
 add_executable(${TEST_TARGET} ${TEST_SOURCES})
-target_link_libraries(${TEST_TARGET} ${GTEST_BOTH_LIBRARIES})
+target_link_libraries(${TEST_TARGET} ${GTEST_BOTH_LIBRARIES} pthread)
 
 # add ctest target, so tests can be executed using `make test`
 add_test(${TEST_TARGET} ${TEST_TARGET})


### PR DESCRIPTION
This fixes linker errors, when linking target `testVirtualJukebox`:

```
/usr/lib/libgtest.a(gtest-all.cc.o): In function `testing::internal::ThreadLocal<testing::TestPartResultReporterInterface*>::~ThreadLocal()':
gtest-all.cc:(.text._ZN7testing8internal11ThreadLocalIPNS_31TestPartResultReporterInterfaceEED2Ev[_ZN7testing8internal11ThreadLocalIPNS_31TestPartResultReporterInterfaceEED5Ev]+0x24): undefined reference to `pthread_getspecific'
```

The same error occurs for all thread functions, like ``pthread_key_delete``,``pthread_key_create`` and similar ones.