### PR TITLE
Build debug version by default.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ project(VirtualJukebox)
 # needed for Doxygen targets
 cmake_policy(SET CMP0054 NEW)
 
+# Build debug version by default, unless specified otherwise
+IF(NOT CMAKE_BUILD_TYPE)
+   SET(CMAKE_BUILD_TYPE Debug)
+ENDIF()
 
 #
 # Sourcen for application and tests


### PR DESCRIPTION
Build debug version of program by default.
This is to make our lifes easier when debugging (which is the case that's mostly used while implementing/working on a project).

Instead of 
`cmake .. -DCMAKE_BUILD_TYPE=Debug`
we can simply call
`cmake ..`