### PR TITLE
Add clang-format CMake target.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,117 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats:
+  - Delimiter:       pb
+    Language:        TextProto
+    BasedOnStyle:    google
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,10 @@
+# A complete list of style options can be found at:
+# http://clang.llvm.org/docs/ClangFormatStyleOptions.html
+#
+# To see the effect of style options, the following tool can be used.
+# https://zed0.co.uk/clang-format-configurator/
+#
+
 ---
 Language:        Cpp
 # BasedOnStyle:  Google
@@ -11,15 +18,15 @@ AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: All
-AllowShortIfStatementsOnASingleLine: true
-AllowShortLoopsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: true
 AlwaysBreakTemplateDeclarations: true
-BinPackArguments: true
-BinPackParameters: true
+BinPackArguments: false
+BinPackParameters: false
 BraceWrapping:
   AfterClass:      false
   AfterControlStatement: false
@@ -59,7 +66,7 @@ ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
-IncludeBlocks:   Preserve
+IncludeBlocks:   Regroup
 IncludeCategories:
   - Regex:           '^<ext/.*\.h>'
     Priority:        2
@@ -110,7 +117,7 @@ SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        Auto
+Standard:        Cpp11
 TabWidth:        8
 UseTab:          Never
 ...

--- a/.clang-format
+++ b/.clang-format
@@ -6,119 +6,14 @@
 #
 
 ---
-Language:        Cpp
-# BasedOnStyle:  Google
-AccessModifierOffset: -1
-AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: false
-AlignEscapedNewlines: Left
-AlignOperands:   true
-AlignTrailingComments: true
-AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: false
-AllowShortCaseLabelsOnASingleLine: false
+Language: Cpp
+BasedOnStyle: Google
 AllowShortFunctionsOnASingleLine: None
-AllowShortIfStatementsOnASingleLine: Never
+AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
-AlwaysBreakAfterDefinitionReturnType: None
-AlwaysBreakAfterReturnType: None
-AlwaysBreakBeforeMultilineStrings: true
-AlwaysBreakTemplateDeclarations: true
 BinPackArguments: false
 BinPackParameters: false
-BraceWrapping:
-  AfterClass:      false
-  AfterControlStatement: false
-  AfterEnum:       false
-  AfterFunction:   false
-  AfterNamespace:  false
-  AfterObjCDeclaration: false
-  AfterStruct:     false
-  AfterUnion:      false
-  AfterExternBlock: false
-  BeforeCatch:     false
-  BeforeElse:      false
-  IndentBraces:    false
-  SplitEmptyFunction: true
-  SplitEmptyRecord: true
-  SplitEmptyNamespace: true
-BreakBeforeBinaryOperators: None
-BreakBeforeBraces: Attach
-BreakBeforeInheritanceComma: false
-BreakBeforeTernaryOperators: true
-BreakConstructorInitializersBeforeComma: false
-BreakConstructorInitializers: BeforeColon
-BreakAfterJavaFieldAnnotations: false
-BreakStringLiterals: true
-ColumnLimit:     80
-CommentPragmas:  '^ IWYU pragma:'
-CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
-ConstructorInitializerIndentWidth: 4
-ContinuationIndentWidth: 4
-Cpp11BracedListStyle: true
-DerivePointerAlignment: true
-DisableFormat:   false
-ExperimentalAutoDetectBinPacking: false
-FixNamespaceComments: true
-ForEachMacros:
-  - foreach
-  - Q_FOREACH
-  - BOOST_FOREACH
-IncludeBlocks:   Regroup
-IncludeCategories:
-  - Regex:           '^<ext/.*\.h>'
-    Priority:        2
-  - Regex:           '^<.*\.h>'
-    Priority:        1
-  - Regex:           '^<.*'
-    Priority:        2
-  - Regex:           '.*'
-    Priority:        3
-IncludeIsMainRegex: '([-_](test|unittest))?$'
-IndentCaseLabels: true
-IndentPPDirectives: None
-IndentWidth:     2
-IndentWrappedFunctionNames: false
-JavaScriptQuotes: Leave
-JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: false
-MacroBlockBegin: ''
-MacroBlockEnd:   ''
-MaxEmptyLinesToKeep: 1
-NamespaceIndentation: None
-ObjCBlockIndentWidth: 2
-ObjCSpaceAfterProperty: false
-ObjCSpaceBeforeProtocolList: false
-PenaltyBreakAssignment: 2
-PenaltyBreakBeforeFirstCallParameter: 1
-PenaltyBreakComment: 300
-PenaltyBreakFirstLessLess: 120
-PenaltyBreakString: 1000
-PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 200
-PointerAlignment: Left
-RawStringFormats:
-  - Delimiter:       pb
-    Language:        TextProto
-    BasedOnStyle:    google
-ReflowComments:  true
-SortIncludes:    true
-SortUsingDeclarations: true
-SpaceAfterCStyleCast: false
-SpaceAfterTemplateKeyword: true
-SpaceBeforeAssignmentOperators: true
-SpaceBeforeParens: ControlStatements
-SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 2
-SpacesInAngles:  false
-SpacesInContainerLiterals: true
-SpacesInCStyleCastParentheses: false
-SpacesInParentheses: false
-SpacesInSquareBrackets: false
-Standard:        Cpp11
-TabWidth:        8
-UseTab:          Never
+IncludeBlocks: Regroup
+Standard: Cpp11
 ...
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ project(VirtualJukebox)
 # needed for Doxygen targets
 cmake_policy(SET CMP0054 NEW)
 
+# Include other CMake sources
+include(cmake/ClangFormat.cmake)
 
 #
 # Sourcen for application and tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,6 @@ project(VirtualJukebox)
 # needed for Doxygen targets
 cmake_policy(SET CMP0054 NEW)
 
-# Include other CMake sources
-include(cmake/ClangFormat.cmake)
 
 #
 # Sourcen for application and tests
@@ -22,6 +20,8 @@ set(TEST_CASE_SOURCES   test/helloworld.cpp)
 # Sources separated in application and test sources
 set(SOURCES      ${ENTRYPOINT_SOURCE} ${APP_SOURCES})
 set(TEST_SOURCES ${APP_SOURCES} ${TEST_CASE_SOURCES})
+
+include(cmake/ClangFormat.cmake)
 
 #
 # Documentation sources

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ TODO
 - CMake (minimum version 3.9)
 - Google Test
 - Doxygen
+- clang-format-6.0
 
 ## Installation
 

--- a/cmake/ClangFormat.cmake
+++ b/cmake/ClangFormat.cmake
@@ -9,11 +9,17 @@ else()
   message(STATUS "clang-format found: ${CLANG_FORMAT_EXE}")
 endif()
 
-if(CLANG_FORMAT_EXE)
-  add_custom_target(
-          clang-format
-          COMMAND clang-format
-          -style=Google
-          -i ${ALL_SOURCE_FILES}
-  )
-endif()
+# Generate absolute paths
+set(CLANG_FORMAT_SOURCES_RELATIVE ${SOURCES} ${TEST_SOURCES})
+foreach(source ${CLANG_FORMAT_SOURCES_RELATIVE})
+  get_filename_component(source ${source} ABSOLUTE)
+  list(APPEND CLANG_FORMAT_SOURCES_ABS ${source})
+endforeach()
+
+add_custom_target(
+  clang-format
+  COMMAND clang-format
+  -style=Google
+  -i
+  ${CLANG_FORMAT_SOURCES_ABS}
+)

--- a/cmake/ClangFormat.cmake
+++ b/cmake/ClangFormat.cmake
@@ -1,12 +1,12 @@
 find_program(
   CLANG_FORMAT_EXE
-  NAMES "clang-format"
-  DOC "Path to clang-format executable"
+  NAMES "clang-format-6.0"
+  DOC "Path to clang-format-6.0 executable"
   )
 if(NOT CLANG_FORMAT_EXE)
-  message(FATAL_ERROR "clang-format not found.")
+  message(FATAL_ERROR "clang-format-6.0 not found.")
 else()
-  message(STATUS "clang-format found: ${CLANG_FORMAT_EXE}")
+  message(STATUS "clang-format-6.0 found: ${CLANG_FORMAT_EXE}")
 endif()
 
 # Generate absolute paths
@@ -18,7 +18,7 @@ endforeach()
 
 add_custom_target(
   clang-format
-  COMMAND clang-format
+  COMMAND ${CLANG_FORMAT_EXE}
   -style=file
   -i
   ${CLANG_FORMAT_SOURCES_ABS}

--- a/cmake/ClangFormat.cmake
+++ b/cmake/ClangFormat.cmake
@@ -1,0 +1,19 @@
+find_program(
+  CLANG_FORMAT_EXE
+  NAMES "clang-format"
+  DOC "Path to clang-format executable"
+  )
+if(NOT CLANG_FORMAT_EXE)
+  message(FATAL_ERROR "clang-format not found.")
+else()
+  message(STATUS "clang-format found: ${CLANG_FORMAT_EXE}")
+endif()
+
+if(CLANG_FORMAT_EXE)
+  add_custom_target(
+          clang-format
+          COMMAND clang-format
+          -style=Google
+          -i ${ALL_SOURCE_FILES}
+  )
+endif()

--- a/cmake/ClangFormat.cmake
+++ b/cmake/ClangFormat.cmake
@@ -19,7 +19,7 @@ endforeach()
 add_custom_target(
   clang-format
   COMMAND clang-format
-  -style=Google
+  -style=file
   -i
   ${CLANG_FORMAT_SOURCES_ABS}
 )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 
-
 int main() {
-    std::cout << "Hello world" << std::endl;
-    return 0;
+  std::cout << "Hello world" << std::endl;
+  return 0;
 }

--- a/test/helloworld.cpp
+++ b/test/helloworld.cpp
@@ -1,6 +1,3 @@
 #include <gtest/gtest.h>
 
-
-TEST(HelloWorld, test1) {
-    EXPECT_EQ(1, 1);
-}
+TEST(HelloWorld, test1) { EXPECT_EQ(1, 1); }

--- a/test/helloworld.cpp
+++ b/test/helloworld.cpp
@@ -1,3 +1,5 @@
 #include <gtest/gtest.h>
 
-TEST(HelloWorld, test1) { EXPECT_EQ(1, 1); }
+TEST(HelloWorld, test1) {
+  EXPECT_EQ(1, 1);
+}


### PR DESCRIPTION
Adds clang-format as a CMake target. 

By using clang-format, we can enforce a common coding-style. 

Simply call `make clang-format`.