### PR TITLE
Fix cmake version issue by not calling cmake.

### DIFF
--- a/scripts/install_librestclient-cpp.sh
+++ b/scripts/install_librestclient-cpp.sh
@@ -10,10 +10,6 @@ cd $SCRIPT_PATH
 cd ../lib/restclient-cpp/
 ./autogen.sh
 ./configure
-mkdir build
-cd build
-cmake ..
-make
 
 # install library files (needs root privileges)
 sudo make install


### PR DESCRIPTION
The error occurs when calling the script `./scripts/install_librestclient-cpp.sh`:
```
config.status: executing libtool commands
CMake Error at CMakeLists.txt:4 (project):
  project with VERSION must use LANGUAGES before language names.

-- Configuring incomplete, errors occurred!
```

This is likely a cmake version issue with the cmake file in lib/restclient-cpp.

However, the install script doesn't actually need to call cmake for restclient-cpp, it can go straight to `make install`. This information was found in the restclient-cpp/README.md.