### PR TITLE
Fix responses of REST endpoints

### DIFF
--- a/src/Network/RestEndpointHandlers.cpp
+++ b/src/Network/RestEndpointHandlers.cpp
@@ -35,8 +35,6 @@ static shared_ptr<http_response> const mapErrorToResponse(Error const &err) {
   static const map<ErrorCode, int> ERROR_TO_HTTP_STATUS = {
       {ErrorCode::AccessDenied, 403},  //
       {ErrorCode::InvalidFormat, 422}  //
-
-      // TODO: add more error codes if they get fixed
   };
 
   int statusCode;
@@ -199,7 +197,7 @@ shared_ptr<http_response> const queryTracksHandler(
   // construct the response
   auto queriedTracks = get<vector<BaseTrack>>(result);
 
-  json jsonTracks;
+  json jsonTracks = json::array();
   for (auto &&track : queriedTracks) {
     jsonTracks.push_back(Serializer::serialize(track));
   }
@@ -229,9 +227,9 @@ shared_ptr<http_response> const getCurrentQueuesHandler(
   // construct the response
   auto queueStatus = get<QueueStatus>(result);
 
-  json playbackTrack;
-  json normalQueue;
-  json adminQueue;
+  json playbackTrack = json::object();
+  json normalQueue = json::array();
+  json adminQueue = json::array();
   if (queueStatus.currentTrack.has_value()) {
     playbackTrack = Serializer::serialize(queueStatus.currentTrack.value());
   }

--- a/src/Network/RestEndpointHandlers.cpp
+++ b/src/Network/RestEndpointHandlers.cpp
@@ -292,7 +292,7 @@ shared_ptr<http_response> const addTrackToQueueHandler(
   }
 
   // construct the response
-  json responseBody = {};
+  json responseBody = json::object();
   return make_shared<string_response>(responseBody.dump());
 }
 
@@ -326,7 +326,7 @@ shared_ptr<http_response> const voteTrackHandler(
   }
 
   // construct the response
-  json responseBody = {};
+  json responseBody = json::object();
   return make_shared<string_response>(responseBody.dump());
 }
 
@@ -378,7 +378,7 @@ shared_ptr<http_response> const controlPlayerHandler(
   }
 
   // construct the response
-  json responseBody = {};
+  json responseBody = json::object();
   return make_shared<string_response>(responseBody.dump());
 }
 
@@ -424,7 +424,7 @@ shared_ptr<http_response> const moveTracksHandler(
   }
 
   // construct the response
-  json responseBody = {};
+  json responseBody = json::object();
   return make_shared<string_response>(responseBody.dump());
 }
 
@@ -459,6 +459,6 @@ shared_ptr<http_response> const removeTrackHandler(
   }
 
   // construct the response
-  json responseBody = {};
+  json responseBody = json::object();
   return make_shared<string_response>(responseBody.dump());
 }

--- a/test/helpers/NetworkListenerHelper.cpp
+++ b/test/helpers/NetworkListenerHelper.cpp
@@ -51,7 +51,7 @@ void testQueryTracks(RestAPIFixture *fixture,
   int maxEntries;
 
   auto expTracks = fixture->gen.generateTracks(expMaxEntries);
-  json expResponseBody = {{"tracks", json{}}};
+  json expResponseBody = {{"tracks", json::array()}};
   for (auto &&track : expTracks) {
     expResponseBody["tracks"].push_back(Serializer::serialize(track));
   }
@@ -89,9 +89,9 @@ void testGetCurrentQueues(RestAPIFixture *fixture,
   auto expQueueStatus =
       fixture->gen.generateQueueStatus(normalNr, adminNr, playbackTrack);
   json expResponseBody = {
-      {"currently_playing", json{}},  //
-      {"normal_queue", json{}},       //
-      {"admin_queue", json{}}         //
+      {"currently_playing", json::object()},  //
+      {"normal_queue", json::array()},        //
+      {"admin_queue", json::array()}          //
   };
 
   if (expQueueStatus.currentTrack.has_value()) {

--- a/test/helpers/NetworkListenerHelper.cpp
+++ b/test/helpers/NetworkListenerHelper.cpp
@@ -150,7 +150,7 @@ void testAddTrackToQueue(RestAPIFixture *fixture,
 
   // check response
   ASSERT_EQ(resp.code, 200);
-  ASSERT_EQ(json::parse(resp.body), json{});
+  ASSERT_EQ(json::parse(resp.body), json::object());
   ASSERT_EQ(fixture->listener.getCountAddTrackToQueue(), count);
 
   ASSERT_TRUE(fixture->listener.hasParametersAddTrackToQueue());
@@ -182,7 +182,7 @@ void testVoteTrack(RestAPIFixture *fixture,
 
   // check response
   ASSERT_EQ(resp.code, 200);
-  ASSERT_EQ(json::parse(resp.body), json{});
+  ASSERT_EQ(json::parse(resp.body), json::object());
   ASSERT_EQ(fixture->listener.getCountVoteTrack(), count);
 
   ASSERT_TRUE(fixture->listener.hasParametersVoteTrack());
@@ -226,7 +226,7 @@ void testControlPlayer(RestAPIFixture *fixture,
 
   // check response
   ASSERT_EQ(resp.code, 200);
-  ASSERT_EQ(json::parse(resp.body), json{});
+  ASSERT_EQ(json::parse(resp.body), json::object());
   ASSERT_EQ(fixture->listener.getCountControlPlayer(), count);
 
   ASSERT_TRUE(fixture->listener.hasParametersControlPlayer());
@@ -264,7 +264,7 @@ void testMoveTrack(RestAPIFixture *fixture,
 
   // check response
   ASSERT_EQ(resp.code, 200);
-  ASSERT_EQ(json::parse(resp.body), json{});
+  ASSERT_EQ(json::parse(resp.body), json::object());
   ASSERT_EQ(fixture->listener.getCountMoveTrack(), count);
 
   ASSERT_TRUE(fixture->listener.hasParametersMoveTrack());


### PR DESCRIPTION
The responses contained `null` for empty arrays or objects. This PR fixes that by responding with empty arrays(`[]`) or objects (`{}`).